### PR TITLE
Update to new Docker Engine and Nvidia-container-toolkit

### DIFF
--- a/Package/Dependency/install-docker.sh
+++ b/Package/Dependency/install-docker.sh
@@ -13,7 +13,8 @@ UBUNTU_NUMBER=$(. /etc/os-release; echo $VERSION_ID) # Ubuntu release number: 24
 
 # uninstall old versions
 for pkg in docker.io docker-doc docker-compose docker-compose-v2 containerd runc;
-  do sudo apt remove $pkg;
+do 
+  sudo apt remove $pkg;
 done
 
 # install docker

--- a/Package/Dependency/install-docker.sh
+++ b/Package/Dependency/install-docker.sh
@@ -8,15 +8,42 @@ set -euo pipefail
 # extends the sudo timeout for another 15 minutes
 sudo -v
 
-# update apt repo
-sudo apt update
+UBUNTU_CODENAME=$(. /etc/os-release; echo $VERSION_CODENAME) # Ubuntu codename: noble (24.04)$
+UBUNTU_NUMBER=$(. /etc/os-release; echo $VERSION_ID) # Ubuntu release number: 24.04 (noble)$
+
+# uninstall old versions
+for pkg in docker.io docker-doc docker-compose docker-compose-v2 containerd runc;
+  do sudo apt remove $pkg;
+done
 
 # install docker
-sudo apt install -y docker.io
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update
+
+# Install the Docker packages
+sudo apt install \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin
 
 # start docker
 sudo systemctl enable --now docker
 
+# create the docker group
+sudo getent group docker || sudo groupadd docker
+
 # add current user to docker group
 sudo usermod -aG docker ${USER}
-

--- a/Package/Dependency/install-virtualgl.sh
+++ b/Package/Dependency/install-virtualgl.sh
@@ -17,7 +17,7 @@ sudo apt install lightdm -y
 sudo dpkg -i /opt/base-env/Package/Archives/virtualgl_2.6.5_amd64.deb
 
 # configure VirtualGL
-sudo vglserver_config -config
+sudo vglserver_config -config +s +f
 
 # add users for accessing vglserver
 sudo usermod -aG vglusers root

--- a/Package/NVIDIA/install-nv-docker.sh
+++ b/Package/NVIDIA/install-nv-docker.sh
@@ -7,18 +7,18 @@ set -euo pipefail
 # extends the sudo timeout for another 15 minutes
 sudo -v
 
-# add the package repositories
-distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | \
-    sudo apt-key add -
-curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | \
-    sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-sudo apt update
+# Configure the production repository
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+    sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
 
-# install nvidia-doceker and restart docker
-sudo apt install -y nvidia-docker2 nvidia-container-toolkit 
-sudo systemctl restart docker
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
+sudo apt-get update
+sudo apt-get install -y nvidia-container-toolkit
+
+# NOTE: this line break the new version nvidia-container-toolkit
 # Change the user who execute nvidia-container-toolkit
 # Reference: https://askubuntu.com/a/1319123
-sudo sed -i 's/^#user.*/user = "root:vglusers"/' /etc/nvidia-container-runtime/config.toml
+# sudo sed -i 's/^#user.*/user = "root:vglusers"/' /etc/nvidia-container-runtime/config.toml


### PR DESCRIPTION
# Docker
- Remove the old `docker.io`
- Install new docker engine
- See https://docs.docker.com/engine/install/ubuntu/

# Nvidia-container-toolkit
- Remove deprecated `nvidia-docker2`
- Install `nvidia-container-toolkit`
- See https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html

# Notice
- Remove the line that change the user who execute nvidia-container-toolkit.

In my test, this line could cause the following error. Removing it allows the GPU to run normally in Docker now.
```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running prestart hook #0: exit status 1, stdout: , stderr: Auto-detected mode as 'legacy'
nvidia-container-cli: input error: parse user/group failed: no such file or directory: unknown

Run 'docker run --help' for more information
```