### PR TITLE
Fix ROCm gpu-status display in MOTD and related ROCm issues

### DIFF
--- a/Script/profile.d/rocm.sh
+++ b/Script/profile.d/rocm.sh
@@ -1,6 +1,6 @@
 export ROCM_HOME="${HOME}/.rocm"
-export PATH="$ROCM_HOME/bin:$PATH$"
+export PATH="$ROCM_HOME/bin:$PATH"
 export LD_LIBRARY_PATH="$ROCM_HOME/lib:$ROCM_HOME/lib64:$LD_LIBRARY_PATH"
-export HIP_VISIBLE_DEVICES=0
+export HIP_VISIBLE_DEVICES="0"
 complete -W "$(ls -d /opt/rocm-* 2> /dev/null | sed 's/\/opt\/rocm-//g')" chrocm
 

--- a/Script/rocm/chrocm
+++ b/Script/rocm/chrocm
@@ -9,6 +9,10 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
+if [ -v HIP_VISIBLE_DEVICES ] && [ -z "${HIP_VISIBLE_DEVICES}" ]; then
+  echo "Warning: \${HIP_VISIBLE_DEVICES} is an empty string"
+fi
+
 VERSION=$1
 PREFIX="/opt/rocm-"
 SOURCE="${PREFIX}${VERSION}"

--- a/Script/server_status/gpu-status
+++ b/Script/server_status/gpu-status
@@ -59,12 +59,11 @@ function gpu_name ()
 
 function amd_info ()
 {
-  SMI=rocm-smi
-  INFO=rocminfo
-  Q_GPU="--showuse --showmeminfo vram --showuniqueid --csv"
+  SMI=$(readlink -f /opt/rocm/bin/rocm-smi)
+  Q_GPU="--showuse --showmeminfo vram --showproductname --csv"
   SKIP_TAIL="head -n -1"
   GPU_INFO=$(${SMI} ${Q_GPU} | ${SKIP_TAIL})
-  PROCESSES=$(${SMI} --showpidgpus | grep -v PID)
+  PROCESSES=$(${SMI} --showpidgpus --csv 2>/dev/null | grep -v "WARNING" | ${SKIP_TAIL} || true)
 
   FIRST=1
   declare -A COL
@@ -77,38 +76,37 @@ function amd_info ()
       continue
     fi
 
-    if [[ ${line[1]} == "N/A" ]] ; then  # skip the integrated GPU
-      continue
-    fi
-
-    GUID=${COL["Unique ID"]}
+    NAME=${COL["Card Series"]}
     UTIL=${COL["GPU use (%)"]}
     MEM_USED=${COL["VRAM Total Used Memory (B)"]}
     MEM_TOT=${COL["VRAM Total Memory (B)"]}
 
-    line[0]=${line[0]/card/}
-    line[${GUID}]=$(gpu_name ${line[${GUID}]})
-    line[${GUID}]=${line[${GUID}]/AMD /}
-    line[${MEM_USED}]=$(( ${line[${MEM_USED}]} / 1024 / 1024 ))
-    line[${MEM_TOT}]=$(( ${line[${MEM_TOT}]} / 1024 / 1024 ))
+    if [[ ${line[${UTIL}]} == "N/A" ]] ; then  # skip the integrated GPU
+      continue
+    fi
+
+    gpu_idx=${line[0]/card/}
+    gpu_name="${line[${NAME}]}"
+    gpu_name="${gpu_name/AMD /}"
+    mem_used=$(( ${line[${MEM_USED}]} / 1024 / 1024 ))
+    mem_free=$(( (${line[${MEM_TOT}]} - ${line[${MEM_USED}]}) / 1024 / 1024 ))
 
     printf "  "
-    printf "${GPU_ARG}" "${line[0]}"
-    printf "${NAME_ARG}" "${line[ ${GUID} ]}"
-    if [ "${line[ ${UTIL} ]}" -gt 85 ]; then
+    printf "${GPU_ARG}" "${gpu_idx}"
+    printf "${NAME_ARG}" "${gpu_name:0:20}"
+    if [ "${line[${UTIL}]}" -gt 85 ]; then
       printf "${RED}"
     else
       printf "${GREEN}"
     fi
-    printf "${UTIL_ARG}${RESET}" "${line[ ${UTIL} ]}%"
-    printf "${MEM_ARG}" "${line[ ${MEM_USED} ]}M"
-    printf "${MEM_ARG}" "${line[ ${MEM_TOT} ]}M"
-    uuid="${line[0]}"
-    echo "${PROCESSES}" | grep "${uuid}" | wc -l
+    printf "${UTIL_ARG}${RESET}" "${line[${UTIL}]}%"
+    printf "${MEM_ARG}" "${mem_used}M"
+    printf "${MEM_ARG}" "${mem_free}M"
+    echo "${PROCESSES}" | grep -c "card${gpu_idx}" 2>/dev/null || true
   done
 }
 
-type nvidia-smi &> /dev/null && nvidia_info
-type rocm-smi &> /dev/null && amd_info
+nvidia-smi &> /dev/null && nvidia_info
+[ -x /opt/rocm/bin/rocm-smi ] && amd_info
 
 exit 0


### PR DESCRIPTION
`gpu-status` was not showing AMD GPU info on login because MOTD scripts run before user profile, so rocm-smi was not in `PATH`.

Changes:
- `gpu-status`: use absolute path for rocm-smi instead of relying on PATH
- `gpu-status`: use --showproductname to get GPU name directly from rocm-smi
- `gpu-status`: fix Free column showing total memory instead of free memory

Tested on zeldajr (4x Radeon AI PRO R9700).